### PR TITLE
Add some profile information to info block

### DIFF
--- a/lib/omniauth/strategies/slack.rb
+++ b/lib/omniauth/strategies/slack.rb
@@ -6,7 +6,7 @@ module OmniAuth
 
       option :name, "slack"
 
-      option :authorize_options, [ :scope, :team ]      
+      option :authorize_options, [ :scope, :team ]
 
       option :client_options, {
         site: "https://slack.com",
@@ -22,6 +22,13 @@ module OmniAuth
 
       info do
         {
+          name: user_info['user']['profile']['real_name_normalized'],
+          email: user_info['user']['profile']['email'],
+          nickname: raw_info['user'],
+          first_name: user_info['user']['profile']['first_name'],
+          last_name: user_info['user']['profile']['last_name'],
+          description: user_info['user']['profile']['title'],
+          image: user_info['user']['profile']['image_192'],
           team: raw_info['team'],
           user: raw_info['user'],
           team_id: raw_info['team_id'],
@@ -30,11 +37,15 @@ module OmniAuth
       end
 
       extra do
-        {:raw_info => raw_info}
+        {:raw_info => raw_info, :user_info => user_info}
+      end
+
+      def user_info
+        @user_info ||= access_token.get("/api/users.info?user=#{raw_info['user_id']}").parsed
       end
 
       def raw_info
-        @raw_info ||= access_token.get('/api/auth.test').parsed
+        @raw_info ||= access_token.get("/api/auth.test").parsed
       end
 
     end


### PR DESCRIPTION
Thanks for creating this gem!

I needed to access some profile informations for my app, so I modified
the info block to include some information returned from the users.info
API call (https://api.slack.com/methods/users.info)

To retrieve this information I also added a `user_info` function, that
requires the `user_id` provided by `raw_info`, and therefore cannot replace
it.

Please let me know what you think.