### PR TITLE
Escape user ID when forming URL

### DIFF
--- a/lib/omniauth/strategies/slack.rb
+++ b/lib/omniauth/strategies/slack.rb
@@ -1,4 +1,6 @@
 require 'omniauth/strategies/oauth2'
+require 'uri'
+require 'rack/utils'
 
 module OmniAuth
   module Strategies
@@ -55,7 +57,11 @@ module OmniAuth
       end
 
       def user_info
-        @user_info ||= access_token.get("/api/users.info?user=#{raw_info['user_id']}").parsed
+        url = URI.parse("/api/users.info")
+        url.query = Rack::Utils.build_query(user: raw_info['user_id'])
+        url = url.to_s
+
+        @user_info ||= access_token.get(url).parsed
       end
 
       def team_info

--- a/test/test.rb
+++ b/test/test.rb
@@ -98,3 +98,25 @@ class CredentialsTest < StrategyTestCase
     refute_has_key "refresh_token", strategy.credentials
   end
 end
+
+class UserInfoTest < StrategyTestCase
+  def setup
+    super
+    @access_token = stub("OAuth2::AccessToken")
+    strategy.stubs(:access_token).returns(@access_token)
+  end
+
+  test "performs a GET to https://slack.com/api/users.info" do
+    strategy.stubs(:raw_info).returns("user_id" => "U123")
+    @access_token.expects(:get).with("/api/users.info?user=U123")
+      .returns(stub_everything("OAuth2::Response"))
+    strategy.user_info
+  end
+
+  test "URI escapes user ID" do
+    strategy.stubs(:raw_info).returns("user_id" => "../haxx?U123#abc")
+    @access_token.expects(:get).with("/api/users.info?user=..%2Fhaxx%3FU123%23abc")
+      .returns(stub_everything("OAuth2::Response"))
+    strategy.user_info
+  end
+end


### PR DESCRIPTION
Prevents a malicious value in `raw_info['user_id']` from doing bad things.