### PR TITLE
Allow OAuth scopes to be space-delimited in addition to comma-delimited

### DIFF
--- a/lib/omniauth/strategies/slack.rb
+++ b/lib/omniauth/strategies/slack.rb
@@ -70,7 +70,7 @@ module OmniAuth
       def incoming_webhook_allowed?
         return false unless options['scope']
         webhooks_scopes = ['incoming-webhook']
-        scopes = options['scope'].split(',')
+        scopes = options['scope'].tr(' ', ',').split(',').reject(&:empty?)
         (scopes & webhooks_scopes).any?
       end
     end

--- a/test/test.rb
+++ b/test/test.rb
@@ -98,3 +98,59 @@ class CredentialsTest < StrategyTestCase
     refute_has_key "refresh_token", strategy.credentials
   end
 end
+
+class ScopeTest < StrategyTestCase
+  test "handles space-delimited scopes when determining if incoming_webhook_allowed?" do
+    options = {
+      'scope' => 'incoming-webhook chat:write:bot'
+    }
+
+    strategy.stubs(:options).returns(options)
+    assert strategy.incoming_webhook_allowed?
+  end
+
+  test "handles comma-delimited scopes when determining if incoming_webhook_allowed?" do
+    options = {
+      'scope' => 'incoming-webhook,chat:write:bot'
+    }
+
+    strategy.stubs(:options).returns(options)
+    assert strategy.incoming_webhook_allowed?
+  end
+
+  test "handles space and comma-delimited scopes when determining if incoming_webhook_allowed?" do
+    options = {
+      'scope' => 'incoming-webhook, chat:write:bot'
+    }
+
+    strategy.stubs(:options).returns(options)
+    assert strategy.incoming_webhook_allowed?
+  end
+
+  test "returns false if incoming-webhook is not in the request scope when determining if incoming_webhook_allowed?" do
+    options = {
+      'scope' => 'chat:write:bot'
+    }
+
+    strategy.stubs(:options).returns(options)
+    refute strategy.incoming_webhook_allowed?
+  end
+
+  test "handles blank scope when determining if incoming_webhook_allowed?" do
+    options = {
+      'scope' => ''
+    }
+
+    strategy.stubs(:options).returns(options)
+    refute strategy.incoming_webhook_allowed?
+  end
+
+  test "handles nil scope when determining if incoming_webhook_allowed?" do
+    options = {
+      'scope' => nil
+    }
+
+    strategy.stubs(:options).returns(options)
+    refute strategy.incoming_webhook_allowed?
+  end
+end


### PR DESCRIPTION
According to Slack's OAuth docs (https://api.slack.com/docs/oauth), OAuth scopes can be space-delimited. However, this gem expects the scopes to be comma-delimited, as at `lib/omniauth/strategies/slack.rb:73`. In the context of that method, having multiple scopes, space-delimted, would cause the gem to skip putting the `incoming_webhook` params in the OAuth response, even if permissions for that scope were requested.

The intention of this PR/commit is to allow for flexibility when determining if `incoming_webhook_allowed?` based on the different, valid, ways of defining permission scopes.