### PR TITLE
Update to reflect changes to Slack scopes

### DIFF
--- a/lib/omniauth/strategies/slack.rb
+++ b/lib/omniauth/strategies/slack.rb
@@ -84,27 +84,13 @@ module OmniAuth
       end
 
       def web_hook_info
-        return {} unless incoming_webhook_allowed?
+        return {} unless access_token.params.key? 'incoming_webhook'
         access_token.params['incoming_webhook']
       end
 
       def bot_info
-        return {} unless bot_allowed?
+        return {} unless access_token.params.key? 'bot'
         access_token.params['bot']
-      end
-
-      def incoming_webhook_allowed?
-        return false unless options['scope']
-        webhooks_scopes = ['incoming-webhook']
-        scopes = options['scope'].split(',')
-        (scopes & webhooks_scopes).any?
-      end
-
-      def bot_allowed?
-        return false unless options['scope']
-        bot_scopes = ['bot']
-        scopes = options['scope'].split(',')
-        (scopes & bot_scopes).any?
       end
     end
   end


### PR DESCRIPTION
Slack has moved to object scopes, so the checks in `incoming_webhook_allowed` and `bot_allowed` are no longer valid. 

The API docs note: 

> If your Slack app includes a bot user, upon approval the JSON response will contain an additional node containing an access token to be specifically used for your bot user, within the context of the approving team.

The same appears to be true for the `incoming_webhook` data

see: https://api.slack.com/docs/oauth-scopes