### PR TITLE
Signin with slack support

### DIFF
--- a/lib/omniauth-slack/response_adapters.rb
+++ b/lib/omniauth-slack/response_adapters.rb
@@ -1,0 +1,3 @@
+require_relative 'response_adapters/base_response_adapter'
+require_relative 'response_adapters/app_scoped_response_adapter'
+require_relative 'response_adapters/identity_scoped_response_adapter'

--- a/lib/omniauth-slack/response_adapters/app_scoped_response_adapter.rb
+++ b/lib/omniauth-slack/response_adapters/app_scoped_response_adapter.rb
@@ -1,0 +1,56 @@
+require 'uri'
+
+module OmniAuth
+  module Slack
+    class AppScopedResponseAdapter < BaseResponseAdapter
+      def info(skip_info)
+        hash = {
+          nickname: raw_info['user'],
+          team: raw_info['team'],
+          user: raw_info['user'],
+          team_id: raw_info['team_id'],
+          user_id: raw_info['user_id']
+        }
+
+        unless skip_info
+          hash.merge!(
+            name: user_info['user'].to_h['profile'].to_h['real_name_normalized'],
+            email: user_info['user'].to_h['profile'].to_h['email'],
+            image_24: user_info['user'].to_h['profile'].to_h['image_24'],
+            image_48: user_info['user'].to_h['profile'].to_h['image_48'],
+            image: user_info['user'].to_h['profile'].to_h['image_192'],
+            first_name: user_info['user'].to_h['profile'].to_h['first_name'],
+            last_name: user_info['user'].to_h['profile'].to_h['last_name'],
+            description: user_info['user'].to_h['profile'].to_h['title'],
+            team_domain: team_info['team'].to_h['domain'],
+            is_admin: user_info['user'].to_h['is_admin'],
+            is_owner: user_info['user'].to_h['is_owner'],
+            time_zone: user_info['user'].to_h['tz']
+          )
+        end
+
+        hash
+      end
+
+      def raw_info
+        @raw_info ||= access_token.get('/api/auth.test').parsed
+      end
+
+      def team_info
+        @team_info ||= access_token.get('/api/team.info').parsed
+      end
+
+      def user_info
+        url = URI.parse("/api/users.info")
+        url.query = Rack::Utils.build_query(user: raw_info['user_id'])
+        url = url.to_s
+
+        @user_info ||= access_token.get(url).parsed
+      end
+
+      def uid
+        raw_info['user_id']
+      end
+    end
+  end
+end

--- a/lib/omniauth-slack/response_adapters/base_response_adapter.rb
+++ b/lib/omniauth-slack/response_adapters/base_response_adapter.rb
@@ -1,0 +1,11 @@
+module OmniAuth
+  module Slack
+    class BaseResponseAdapter
+      attr_reader :access_token
+
+      def initialize(access_token)
+        @access_token = access_token
+      end
+    end
+  end
+end

--- a/lib/omniauth-slack/response_adapters/identity_scoped_response_adapter.rb
+++ b/lib/omniauth-slack/response_adapters/identity_scoped_response_adapter.rb
@@ -1,0 +1,43 @@
+module OmniAuth
+  module Slack
+    class IdentityScopedResponseAdapter < BaseResponseAdapter
+      def info(skip_info)
+        hash = {
+          nickname: raw_info['user']['name'],
+          team: raw_info['team']['name'],
+          user: raw_info['user']['name'],
+          team_id: raw_info['team']['id'],
+          user_id: raw_info['user']['id']
+        }
+
+        unless skip_info
+          hash.merge!(
+            name: user_info['name'],
+            email: user_info['email'],
+            image_24: user_info['image_24'],
+            image_48: user_info['image_48'],
+            image: user_info['image_192']
+          )
+        end
+
+        hash
+      end
+
+      def raw_info
+        @raw_info ||= access_token.get('/api/users.identity').parsed
+      end
+
+      def team_info
+        @team_info ||= raw_info['team']
+      end
+
+      def uid
+        raw_info['user']['id']
+      end
+
+      def user_info
+        @user_info ||= raw_info["user"]
+      end
+    end
+  end
+end

--- a/lib/omniauth-slack/response_adapters/identity_scoped_response_adapter.rb
+++ b/lib/omniauth-slack/response_adapters/identity_scoped_response_adapter.rb
@@ -28,15 +28,15 @@ module OmniAuth
       end
 
       def team_info
-        @team_info ||= raw_info['team']
+        @team_info ||= raw_info['team'].to_h
       end
 
       def uid
-        raw_info['user']['id']
+        user_info['id']
       end
 
       def user_info
-        @user_info ||= raw_info["user"]
+        @user_info ||= raw_info['user'].to_h
       end
     end
   end

--- a/lib/omniauth/strategies/slack.rb
+++ b/lib/omniauth/strategies/slack.rb
@@ -102,6 +102,10 @@ module OmniAuth
         return {} unless access_token.params.key? 'bot'
         access_token.params['bot']
       end
+
+      def identity_scoped?
+        authorize_params[:scope] =~ /identity\.basic/
+      end
     end
   end
 end

--- a/lib/omniauth/strategies/slack.rb
+++ b/lib/omniauth/strategies/slack.rb
@@ -19,7 +19,7 @@ module OmniAuth
         param_name: 'token'
       }
 
-      uid { raw_info['user_id'] }
+      uid { identity_scoped? ? raw_info['user']['id'] : raw_info['user_id'] }
 
       info do
         hash = {
@@ -84,11 +84,15 @@ module OmniAuth
       end
 
       def user_info
-        url = URI.parse("/api/users.info")
-        url.query = Rack::Utils.build_query(user: raw_info['user_id'])
-        url = url.to_s
+        if identity_scoped?
+          @user_info ||= raw_info["user"]
+        else
+          url = URI.parse("/api/users.info")
+          url.query = Rack::Utils.build_query(user: raw_info['user_id'])
+          url = url.to_s
 
-        @user_info ||= access_token.get(url).parsed
+          @user_info ||= access_token.get(url).parsed
+        end
       end
 
       def team_info

--- a/lib/omniauth/strategies/slack.rb
+++ b/lib/omniauth/strategies/slack.rb
@@ -68,7 +68,9 @@ module OmniAuth
       end
 
       def raw_info
-        @raw_info ||= access_token.get('/api/auth.test').parsed
+        @raw_info ||= identity_scoped? ?
+          access_token.get('/api/users.identity').parsed :
+          access_token.get('/api/auth.test').parsed
       end
 
       def authorize_params

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -41,6 +41,7 @@ class StrategyTestCase < TestCase
 
     @client_id = "123"
     @client_secret = "53cr3tz"
+    @options = nil
   end
 
   def strategy

--- a/test/test.rb
+++ b/test/test.rb
@@ -121,6 +121,27 @@ class IdentityScopeTest < StrategyTestCase
   end
 end
 
+class RawInfoTest < StrategyTestCase
+  def setup
+    super
+    @access_token = stub("OAuth2::AccessToken")
+    strategy.stubs(:access_token).returns(@access_token)
+  end
+
+  test "performs a GET to https://slack.com/api/auth.test" do
+    @access_token.expects(:get).with("/api/auth.test")
+      .returns(stub_everything("OAuth2::Response"))
+    strategy.raw_info
+  end
+
+  test "performs a GET to https://slack.com/api/users.identity for identity scopes" do
+    strategy.stubs(:identity_scoped?).returns(true)
+    @access_token.expects(:get).with("/api/users.identity")
+      .returns(stub_everything("OAuth2::Response"))
+    strategy.raw_info
+  end
+end
+
 class UserInfoTest < StrategyTestCase
 
   def setup

--- a/test/test.rb
+++ b/test/test.rb
@@ -133,7 +133,8 @@ class SkipInfoTest < StrategyTestCase
   test 'extra should not include extended info when skip_info is specified' do
     @options = { skip_info: true }
     strategy.stubs(:raw_info).returns({})
-    strategy.stubs(:webhook_info).returns({})
+    strategy.stubs(:bot_info).returns({})
+    strategy.stubs(:web_hook_info).returns({})
     assert_equal %w[raw_info web_hook_info bot_info], strategy.extra.keys.map(&:to_s)
   end
 

--- a/test/test.rb
+++ b/test/test.rb
@@ -37,12 +37,14 @@ class CallbackUrlTest < StrategyTestCase
 end
 
 class UidTest < StrategyTestCase
-  def setup
-    super
+  test "returns the user ID from raw_info" do
     strategy.stubs(:raw_info).returns("user_id" => "U123")
+    assert_equal "U123", strategy.uid
   end
 
-  test "returns the user ID from raw_info" do
+  test "returns the user ID from raw info for identity scoped requests" do
+    strategy.stubs(:raw_info).returns("user" => { "id" => "U123" })
+    strategy.stubs(:identity_scoped?).returns true
     assert_equal "U123", strategy.uid
   end
 end
@@ -162,6 +164,13 @@ class UserInfoTest < StrategyTestCase
     @access_token.expects(:get).with("/api/users.info?user=..%2Fhaxx%3FU123%23abc")
       .returns(stub_everything("OAuth2::Response"))
     strategy.user_info
+  end
+
+  test "returns the existing user info for identity scopes" do
+    user_info = { "id" => "U123", "name" => "Jimmy Page" }
+    strategy.stubs(:raw_info).returns("user" => user_info)
+    strategy.stubs(:identity_scoped?).returns(true)
+    assert_equal strategy.user_info, user_info
   end
 end
 

--- a/test/test.rb
+++ b/test/test.rb
@@ -99,6 +99,28 @@ class CredentialsTest < StrategyTestCase
   end
 end
 
+class IdentityScopeTest < StrategyTestCase
+  test "identity scoped if it includes an identity.basic scope" do
+    @options = { authorize_options: [:scope], scope: "identity.basic" }
+    assert strategy.identity_scoped?
+  end
+
+  test "identity scoped if scope includes additional scopes" do
+    @options = { authorize_options: [:scope],
+                 scope: "team.read,identity.basic,users.read" }
+    assert strategy.identity_scoped?
+  end
+
+  test "not identity scope if it does not include identity.basic scope" do
+    @options = { authorize_options: [:scope], scope: "identity.email" }
+    assert !strategy.identity_scoped?
+  end
+
+  test "not identity scope if a scope is not included" do
+    assert !strategy.identity_scoped?
+  end
+end
+
 class UserInfoTest < StrategyTestCase
 
   def setup

--- a/test/test.rb
+++ b/test/test.rb
@@ -38,13 +38,13 @@ end
 
 class UidTest < StrategyTestCase
   test "returns the user ID from raw_info" do
-    strategy.stubs(:raw_info).returns("user_id" => "U123")
+    strategy.response_adapter.stubs(:raw_info).returns("user_id" => "U123")
     assert_equal "U123", strategy.uid
   end
 
   test "returns the user ID from raw info for identity scoped requests" do
-    strategy.stubs(:raw_info).returns("user" => { "id" => "U123" })
     strategy.stubs(:identity_scoped?).returns true
+    strategy.response_adapter.stubs(:raw_info).returns("user" => { "id" => "U123" })
     assert_equal "U123", strategy.uid
   end
 end
@@ -153,23 +153,23 @@ class UserInfoTest < StrategyTestCase
   end
 
   test "performs a GET to https://slack.com/api/users.info" do
-    strategy.stubs(:raw_info).returns("user_id" => "U123")
+    strategy.response_adapter.stubs(:raw_info).returns("user_id" => "U123")
     @access_token.expects(:get).with("/api/users.info?user=U123")
       .returns(stub_everything("OAuth2::Response"))
     strategy.user_info
   end
 
   test "URI escapes user ID" do
-    strategy.stubs(:raw_info).returns("user_id" => "../haxx?U123#abc")
+    strategy.response_adapter.stubs(:raw_info).returns("user_id" => "../haxx?U123#abc")
     @access_token.expects(:get).with("/api/users.info?user=..%2Fhaxx%3FU123%23abc")
       .returns(stub_everything("OAuth2::Response"))
     strategy.user_info
   end
 
   test "returns the existing user info for identity scopes" do
-    user_info = { "id" => "U123", "name" => "Jimmy Page" }
-    strategy.stubs(:raw_info).returns("user" => user_info)
     strategy.stubs(:identity_scoped?).returns(true)
+    user_info = { "id" => "U123", "name" => "Jimmy Page" }
+    strategy.response_adapter.stubs(:raw_info).returns("user" => user_info)
     assert_equal strategy.user_info, user_info
   end
 end
@@ -178,13 +178,13 @@ class SkipInfoTest < StrategyTestCase
 
   test 'info should not include extended info when skip_info is specified' do
     @options = { skip_info: true }
-    strategy.stubs(:raw_info).returns({})
+    strategy.response_adapter.stubs(:raw_info).returns({})
     assert_equal %w[nickname team user team_id user_id], strategy.info.keys.map(&:to_s)
   end
 
   test 'extra should not include extended info when skip_info is specified' do
     @options = { skip_info: true }
-    strategy.stubs(:raw_info).returns({})
+    strategy.response_adapter.stubs(:raw_info).returns({})
     strategy.stubs(:bot_info).returns({})
     strategy.stubs(:web_hook_info).returns({})
     assert_equal %w[raw_info web_hook_info bot_info], strategy.extra.keys.map(&:to_s)


### PR DESCRIPTION
This PR adds [Sign in with Slack](https://api.slack.com/docs/sign-in-with-slack) support via an adapter pattern.

Since Slack responds with a different JSON structure with `identity` scopes and `app` scopes, this PR introduces an adapter for each different scope so it has a common API to respond with `user_info`, `raw_info`, `team_info`, and the `uid`.

For example, an app requesting the `identity.basic` scope needs to call the [/api/users.identity](https://api.slack.com/methods/users.identity) whereas the non-`identity` scopes needs to call the [/api/auth.test](https://api.slack.com/methods/auth.test) method. These two methods return different JSON responses with different structures.

*_This PR will not merge with the current master. This is because another PR that added sign in with Slack support eliminated a lot of the information provided by the strategy. Information such as `user_id` and `team_id` which I believe will break a lot of current installs. I recommend replacing it with this PR since it does not eliminate the fidelity of the current information that is provided by the strategy. *_
