### PR TITLE
Monkey patch to work with Add to Slack flow

### DIFF
--- a/lib/omniauth-slack.rb
+++ b/lib/omniauth-slack.rb
@@ -1,2 +1,3 @@
 require 'omniauth-slack/version'
-require 'omniauth/strategies/slack'
+require 'omniauth/strategies/slack_add'
+require 'omniauth/strategies/slack_sign_in'

--- a/lib/omniauth/strategies/slack.rb
+++ b/lib/omniauth/strategies/slack.rb
@@ -63,20 +63,34 @@ module OmniAuth
       end
 
       def identity
-        @identity ||= access_token.get('/api/users.identity').parsed
+        url = if options.scope.include?("identity")
+          '/api/users.identity'
+        else
+          '/api/auth.test'
+        end
+
+        @identity ||= access_token.get(url).parsed
       end
 
       def user_identity
-        @user_identity ||= identity['user'].to_h
+        if options.scope.include?("identity")
+          @user_identity ||= identity['user'].to_h
+        else
+          @user_identity ||= identity
+        end
       end
 
       def team_identity
-        @team_identity ||= identity['team'].to_h
+        if options.scope.include?("identity")
+          @team_identity ||= identity['team'].to_h
+        else
+          identity
+        end
       end
 
       def user_info
         url = URI.parse('/api/users.info')
-        url.query = Rack::Utils.build_query(user: user_identity['id'])
+        url.query = Rack::Utils.build_query(user: user_identity['id'] || user_identity['user_id'])
         url = url.to_s
 
         @user_info ||= access_token.get(url).parsed

--- a/lib/omniauth/strategies/slack_add.rb
+++ b/lib/omniauth/strategies/slack_add.rb
@@ -1,0 +1,99 @@
+require 'omniauth/strategies/oauth2'
+require 'uri'
+require 'rack/utils'
+
+module OmniAuth
+  module Strategies
+    class SlackAdd < OmniAuth::Strategies::OAuth2
+      option :name, 'alt_slack'
+
+      option :authorize_options, [:scope, :team]
+
+      option :client_options, {
+        site: 'https://slack.com',
+        token_url: '/api/oauth.access'
+      }
+
+      option :auth_token_params, {
+        mode: :query,
+        param_name: 'token'
+      }
+
+      # User ID is not guaranteed to be globally unique across all Slack users.
+      # The combination of user ID and team ID, on the other hand, is guaranteed
+      # to be globally unique.
+      uid { "#{identity['user_id']}-#{identity['team_id']}" }
+
+      info do
+        hash = {
+          name: hash_dig(user_info, 'user', 'name') || identity['user'],
+          username: identity['user'],
+          email: hash_dig(user_info, 'user', 'profile', 'email'),
+          team_name: identity['team'],
+          team_id: identity['team_id'],
+        }
+
+        unless skip_info?
+          [:first_name, :last_name, :phone, :image_48].each do |key|
+            hash[key] = hash_dig(user_info, 'user', 'profile', key)
+          end
+        end
+
+        hash
+      end
+
+      extra do
+        {
+          raw_info: {
+            user_info: user_info,         # Requires the users:read scope
+            team_info: team_info,         # Requires the team:read scope
+            web_hook_info: web_hook_info,
+            bot_info: bot_info
+          }
+        }
+      end
+
+      def authorize_params
+        super.tap do |params|
+          %w[scope team].each do |v|
+            if request.params[v]
+              params[v.to_sym] = request.params[v]
+            end
+          end
+        end
+      end
+
+      def hash_dig(hash, *keys)
+        keys.inject(hash) do |result, method|
+          result[method.to_s] if result
+        end
+      end
+
+      def identity
+        url = '/api/auth.test'
+
+        @identity ||= access_token.get(url).parsed
+      end
+
+      def user_info
+        url = URI.parse('/api/users.info')
+        url.query = Rack::Utils.build_query(user: identity['user_id'])
+        url = url.to_s
+
+        @user_info ||= access_token.get(url).parsed
+      end
+
+      def team_info
+        @team_info ||= access_token.get('/api/team.info').parsed
+      end
+
+      def web_hook_info
+        access_token.params['incoming_webhook'].to_h
+      end
+
+      def bot_info
+        access_token.params['bot'].to_h
+      end
+    end
+  end
+end


### PR DESCRIPTION
The Add to Slack flow doesn't currently work for me.

The reason for that I can't ask for the `identity.basic` scope (slack does not allow asking for this scope along with other scopes), yet the gem assumes this scope is there when it asks for the user info
## Update after refactors

I now had time to do this properly. It seems to me that we don't need to use `/api/users.identity` at all
In the initial OAuth response, we already get everything we need for the info hash (user id, and a username which can be used as fallback for the name).
A subsequent request is still made to `/api/users.info` just like before, and if this info is available, it's data will be used where appropriate

I'm relying only on `/api/auth.test` to get the main info, which I believe is always available in both the Sign In Flow and the Add to Slack flow.

I'll now be testing this further, but assuming it works, I'll start using my branch for my current app. I'm not sure if these changes are valid for everyone though, but should this be merged, it should probably require a version bump since it changes some stuff on the resulting OAuth hash
## Old description (no need to read, just here for documentation purposes)

For now, I just hacked a quick solution (out of time for the day, unfortunately), which fallsback to the `auth.test` method when the identity scope is not available.
This ended up causing me to have to monkey patch a bunch of other things temporarily, just to make this thing work for now

Perhaps the `auth.test` method can be used all the time, instead of `users.identify` being the default? It seems to me that it would work for this, since we're simply using it to get the user_id when later calling `users.info`

Either way, I posted this here already because someone might have already come up with a solution, or I may just be missing something obvious, before proceeding with refactoring this, since it is quite urgent for me
