### PR TITLE
Allow inclusion of custom redirect_uri when configuring provider

### DIFF
--- a/lib/omniauth/strategies/slack.rb
+++ b/lib/omniauth/strategies/slack.rb
@@ -7,7 +7,7 @@ module OmniAuth
     class Slack < OmniAuth::Strategies::OAuth2
       option :name, 'slack'
 
-      option :authorize_options, [:scope, :team]
+      option :authorize_options, [:scope, :team, :redirect_uri]
 
       option :client_options, {
         site: 'https://slack.com',


### PR DESCRIPTION
In certain scenarios (for instance when coming from a slack team style subdomain) we want the ability to set a custom redirect_uri, since Slack doesn't allow a wildcard for the subdomain. 

Example: Your application allows creation of arbitrary team subdomains (exactly how Slack works). The user clicks the Add to Slack from `subdomain1.example.com`. However the allowable redirect_uri in the Slack App settings is `www.example.com/slack/*`. This will break because the gem will currently set the redirect_uri from the current location. 
