### PR TITLE
Fix user_info method for Add to Slack

### DIFF
--- a/lib/omniauth/strategies/slack.rb
+++ b/lib/omniauth/strategies/slack.rb
@@ -76,7 +76,7 @@ module OmniAuth
 
       def user_info
         url = URI.parse('/api/users.info')
-        url.query = Rack::Utils.build_query(user: user_identity['id'])
+        url.query = Rack::Utils.build_query(user: user_identity['id'] || access_token.params["user_id"])
         url = url.to_s
 
         @user_info ||= access_token.get(url).parsed


### PR DESCRIPTION
When going through an initial Add to Slack flow, you can't mix the `identity.basic` scope with other team-wide scopes being requested (like `team:read` or `users:read`). However, Slack does give us the currently signed in user_id inside our `access_token.params` object. So, if for whatever reason our user_identity['id'] is nil, we should grab the user_id from `access_token.params` so that we get the current users information instead of an error.
