### PR TITLE
Expose users.identity information in omniauth_hash.extra.

### DIFF
--- a/lib/omniauth/strategies/slack.rb
+++ b/lib/omniauth/strategies/slack.rb
@@ -44,6 +44,8 @@ module OmniAuth
       extra do
         {
           raw_info: {
+            team_identity: team_identity,  # Requires identify:basic scope
+            user_identity: user_identity,  # Requires identify:basic scope
             user_info: user_info,         # Requires the users:read scope
             team_info: team_info,         # Requires the team:read scope
             web_hook_info: web_hook_info,


### PR DESCRIPTION
The gem does a pretty good job of filling in the `info` fields in `omniauth_hash`. This PR exposes the rest of the informaton returned by Slack's `users.identity` API call as the `team_identity` and `user_identity` members of the `omniauth_hash.extra.raw_info` hash. 

This is useful, for example, to extract different image sizes for the user / team avatars.

Thank you very much for this great gem!