### PR TITLE
Fix #46 - Bump dependency version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source 'http://rubygems.org'
 
 # Specify your gem's dependencies in omniauth-slack.gemspec
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in omniauth-slack.gemspec
 gemspec

--- a/omniauth-slack.gemspec
+++ b/omniauth-slack.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'omniauth-oauth2', "~> 1.3.1"
+  spec.add_runtime_dependency 'omniauth-oauth2', "~> 1.4"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", "~> 1.11.2"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "mocha"


### PR DESCRIPTION
Bumping up `omniauth-oauth2` to the most current version `1.4.0` to ensure compatibility with other omniauth solutions.
kmrshntr/omniauth-slack#46