### PR TITLE
query_string cut from method callback_url

### DIFF
--- a/lib/omniauth/strategies/slack.rb
+++ b/lib/omniauth/strategies/slack.rb
@@ -97,6 +97,12 @@ module OmniAuth
         return {} unless access_token.params.key? 'bot'
         access_token.params['bot']
       end
+
+      private
+
+      def callback_url
+        full_host + script_name + callback_path
+      end
     end
   end
 end


### PR DESCRIPTION
This fix an error "{"ok":false,"error":"bad_redirect_uri"}" when i want get access token