### PR TITLE
Add identity information to the "Add to Slack" flow.

### DIFF
--- a/lib/omniauth/strategies/slack.rb
+++ b/lib/omniauth/strategies/slack.rb
@@ -7,7 +7,7 @@ module OmniAuth
     class Slack < OmniAuth::Strategies::OAuth2
       option :name, 'slack'
 
-      option :authorize_options, [:scope, :team]
+      option :authorize_options, [:scope, :team, :redirect_uri]
 
       option :client_options, {
         site: 'https://slack.com',

--- a/lib/omniauth/strategies/slack.rb
+++ b/lib/omniauth/strategies/slack.rb
@@ -114,7 +114,7 @@ module OmniAuth
       #   full_host + script_name + callback_path
       # end
       def callback_url
-        authorization_params.redirect_uri
+        authorize_params.redirect_uri
       end
 
       def identity_to_info

--- a/lib/omniauth/strategies/slack.rb
+++ b/lib/omniauth/strategies/slack.rb
@@ -110,9 +110,9 @@ module OmniAuth
 
       private
 
-      def callback_url
-        full_host + script_name + callback_path
-      end
+      # def callback_url
+      #   full_host + script_name + callback_path
+      # end
 
       def identity_to_info
         hash = {

--- a/lib/omniauth/strategies/slack.rb
+++ b/lib/omniauth/strategies/slack.rb
@@ -48,7 +48,7 @@ module OmniAuth
 
       def authorize_params
         super.tap do |params|
-          %w[scope team].each do |v|
+          %w[scope team redirect_uri].each do |v|
             if request.params[v]
               params[v.to_sym] = request.params[v]
             end

--- a/lib/omniauth/strategies/slack.rb
+++ b/lib/omniauth/strategies/slack.rb
@@ -25,25 +25,17 @@ module OmniAuth
       uid { "#{user_identity['id']}-#{team_identity['id']}" }
 
       info do
-        hash = {
-          name: user_identity['name'],
-          email: user_identity['email'],    # Requires the identity.email scope
-          image: user_identity['image_48'], # Requires the identity.avatar scope
-          team_name: team_identity['name']  # Requires the identity.team scope
-        }
-
-        unless skip_info?
-          [:first_name, :last_name, :phone].each do |key|
-            hash[key] = user_info['user'].to_h['profile'].to_h[key.to_s]
-          end
+        if authorize_params.scope.include?('identity.basic')
+          identity_to_info
+        else
+          user_info_to_info
         end
-
-        hash
       end
 
       extra do
         {
           raw_info: {
+            auth_test: auth_test,
             team_identity: team_identity,  # Requires identify:basic scope
             user_identity: user_identity,  # Requires identify:basic scope
             user_info: user_info,         # Requires the users:read scope
@@ -64,21 +56,39 @@ module OmniAuth
         end
       end
 
+      def auth_test
+        @auth_test ||= access_token.get('/api/auth.test').parsed
+      end
+
       def identity
         @identity ||= access_token.get('/api/users.identity').parsed
       end
 
       def user_identity
-        @user_identity ||= identity['user'].to_h
+        @user_identity ||= if authorize_params.scope.include?('identity.basic')
+          identity['user'].to_h
+        else
+          {}
+        end
       end
 
       def team_identity
-        @team_identity ||= identity['team'].to_h
+        @team_identity ||= if authorize_params.scope.include?('identity.basic')
+          identity['team'].to_h
+        else
+          {}
+        end
       end
 
       def user_info
+        user_id = if authorize_params.scope.include?('identity.basic')
+          user_identity['id']
+        else
+          auth_test['user_id']
+        end
+
         url = URI.parse('/api/users.info')
-        url.query = Rack::Utils.build_query(user: user_identity['id'])
+        url.query = Rack::Utils.build_query(user: user_id)
         url = url.to_s
 
         @user_info ||= access_token.get(url).parsed
@@ -103,6 +113,43 @@ module OmniAuth
       def callback_url
         full_host + script_name + callback_path
       end
+
+      def identity_to_info
+        hash = {
+          name: user_identity['name'],
+          username: user_identity['username'],
+          email: user_identity['email'],    # Requires the identity.email scope
+          image: user_identity['image_48'], # Requires the identity.avatar scope
+          team_name: team_identity['name']  # Requires the identity.team scope
+        }
+
+        unless skip_info?
+          [:first_name, :last_name, :phone].each do |key|
+            hash[key] = user_info['user'].to_h['profile'].to_h[key.to_s]
+          end
+        end
+
+        hash
+      end
+
+      def user_info_to_info
+        hash = {
+          name: user_info['user']['real_name'],
+          username: user_info['user']['name'],
+          email: user_info['user']['profile']['email'],    # Requires the users:read scope
+          image: user_info['user']['profile']['image_48'], # Requires the users:read scope
+          team_name: team_info['team']['name']     # Requires the users:read scope
+        }
+
+        unless skip_info?
+          [:first_name, :last_name, :phone].each do |key|
+            hash[key] = user_info['user'].to_h['profile'].to_h[key.to_s]
+          end
+        end
+
+        hash
+      end
+
     end
   end
 end

--- a/lib/omniauth/strategies/slack.rb
+++ b/lib/omniauth/strategies/slack.rb
@@ -91,7 +91,7 @@ module OmniAuth
         url.query = Rack::Utils.build_query(user: user_id)
         url = url.to_s
 
-        @user_info ||= access_token.get(url).parsed
+        @user_info ||= access_token.get(url).parsed['user']
       end
 
       def team_info

--- a/lib/omniauth/strategies/slack.rb
+++ b/lib/omniauth/strategies/slack.rb
@@ -48,7 +48,7 @@ module OmniAuth
 
       def authorize_params
         super.tap do |params|
-          %w[scope team redirect_uri].each do |v|
+          %w[scope team].each do |v|
             if request.params[v]
               params[v.to_sym] = request.params[v]
             end
@@ -113,6 +113,9 @@ module OmniAuth
       # def callback_url
       #   full_host + script_name + callback_path
       # end
+      def callback_url
+        authorization_params.redirect_uri
+      end
 
       def identity_to_info
         hash = {


### PR DESCRIPTION
It is well known that Slack requires identity scopes to be separate from additional scopes. This typically requires pushing a user down the OAuth flow twice (once for "Sign in with Slack" and one with "Add to Slack").

This solution addresses that by gathering the information normally in the identity scopes from the "Add to Slack" flow by calling the `auth.test` and `users.info` APIs and stuffing the data conditionally.

Also, allow `redirect_uri` to be defined on the configuration.

I would like to see this get merged into master.