### PR TITLE
Update ominauth-oauth2 to fix Hashie warning

### DIFF
--- a/lib/omniauth-slack/version.rb
+++ b/lib/omniauth-slack/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Slack
-    VERSION = "2.3.0"
+    VERSION = "2.3.1"
   end
 end

--- a/omniauth-slack.gemspec
+++ b/omniauth-slack.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'omniauth-oauth2', "~> 1.4"
+  spec.add_runtime_dependency 'omniauth-oauth2', "~> 1.6"
 
   spec.add_development_dependency "bundler", "~> 1.11.2"
   spec.add_development_dependency "rake"

--- a/omniauth-slack.gemspec
+++ b/omniauth-slack.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'omniauth-oauth2', "~> 1.6"
+  spec.add_runtime_dependency 'omniauth-oauth2', "~> 1.5"
 
   spec.add_development_dependency "bundler", "~> 1.11.2"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
See this issue for context: https://github.com/omniauth/omniauth/issues/872

Logs will be flooded with warnings, and new `omniauth-oauth2` release contains the fix for that.

```
W, [2018-01-13T16:50:59.374198 #326]  WARN -- : You are setting a key that conflicts with a 
built-in method OmniAuth::AuthHash::InfoHash#name defined 
at /app/vendor/bundle/ruby/2.4.0/gems/omniauth-1.3.1/lib/omniauth/auth_hash.rb:34. 
This can cause unexpected behavior when accessing the key as a property. 
You can still access the key via the #[] method.
```